### PR TITLE
Keep formatting in user messages

### DIFF
--- a/bookmark.js
+++ b/bookmark.js
@@ -3,6 +3,7 @@ javascript:(function() {
   a.href = URL.createObjectURL(new Blob([`<!DOCTYPE html><html><head><style>
 [class^="react-scroll-to-bottom"] > .flex > div:nth-child(2n+1) {
     background: lightgray;
+    white-space: pre;
 }
 [class^="react-scroll-to-bottom"] > .flex > div:nth-child(2n+2) {
     background: darkgray;

--- a/bookmark.js
+++ b/bookmark.js
@@ -3,7 +3,7 @@ javascript:(function() {
   a.href = URL.createObjectURL(new Blob([`<!DOCTYPE html><html><head><style>
 [class^="react-scroll-to-bottom"] > .flex > div:nth-child(2n+1) {
     background: lightgray;
-    white-space: pre;
+    white-space: pre-wrap;
 }
 [class^="react-scroll-to-bottom"] > .flex > div:nth-child(2n+2) {
     background: darkgray;


### PR DESCRIPTION
ChatGPT can use HTML formatting but we just get plain newline characters and spaces.

Styling the messages with `pre` tells the browser to display all the whitespace as-is which keeps the messages formatted as they are intended.