### PR TITLE
Added handling OpenAI warnings

### DIFF
--- a/bookmark.js
+++ b/bookmark.js
@@ -12,7 +12,7 @@ javascript:(async function() {
       .replace(non_letters_re, "-")
       .replace(trailing_dash_re, '');
     template.innerHTML = dom.innerHTML;
-    ['.items-end', 'img', 'svg', 'button', ':empty', '.items-end .text-xs'].forEach(selector => {
+    ['.items-end', 'img', 'svg', 'button', ':empty', '.rounded-full', '.items-end .text-xs'].forEach(selector => {
       template.content.querySelectorAll(selector).forEach(node => {
         if (!node.closest('.math') && !is_avatar(node)) {
           node.remove();
@@ -230,6 +230,31 @@ code.hljs, code[class*=language-], pre[class*=language-] {
 }
 .overflow-y-auto {
   overflow-y: auto;
+}
+/* style of the warnings */
+.text-sm {
+  font-size: .875rem;
+  line-height: 1.25rem;
+}
+.py-2 {
+  padding-bottom: .5rem;
+  padding-top: .5rem;
+}
+.px-3 {
+  padding-left: .75rem;
+  padding-right: .75rem;
+}
+.bg-orange-500/10 {
+  --tw-bg-opacity: 1;
+  background-color: rgba(224,108,43,var(--tw-bg-opacity));
+}
+.border-orange-500 {
+  --tw-text-opacity: 1;
+  border-color: rgba(224,108,43,var(--tw-text-opacity));
+  color: rgba(224,108,43,var(--tw-text-opacity));
+}
+.border {
+  border-width: 1px;
 }
 </style>
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.4/dist/katex.min.css"/>

--- a/bookmark.js
+++ b/bookmark.js
@@ -53,6 +53,9 @@ body > .w-full {
 .text-base {
   max-width: 50rem;
 }
+.gap-4 {
+  gap: 1rem;
+}
 /* prompt */
 body > .w-full:nth-child(2n+1) {
   background: rgb(52,53,65);

--- a/bookmark.js
+++ b/bookmark.js
@@ -310,6 +310,6 @@ document.querySelectorAll('img').forEach(img => {
         image.addEventListener('load', resolve, { once: true });
         image.scrollIntoView();
       }
-    }
+    })
   }
 })();


### PR DESCRIPTION
I added the possibility to show even warnings inside the exported chat. The result is similar to the original. I just put the warning color on the text and deleted the exclamation mark icon so that the text remained white like the rest of the conversation and is easier to manage without using complicated css.

Chat:
<img width="815" alt="Screenshot 2023-04-13 at 4 36 22 PM" src="https://user-images.githubusercontent.com/32281481/231797927-2cf3b2f8-1ba4-4886-ba30-f1c7b4ca38f1.png">

Exported Chat:
<img width="887" alt="Screenshot 2023-04-13 at 4 42 15 PM" src="https://user-images.githubusercontent.com/32281481/231797874-f01ab2b3-4a6b-4f27-bc87-56b7bff3e8c4.png">
